### PR TITLE
Added CircleCI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+
+jobs:
+  build:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Download Premake5
+          command: 'wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha13/premake-5.0.0-alpha13-linux.tar.gz'
+      - run:
+          name: Install Premake5
+          command: 'tar -xvf premake-5.0.0-alpha13-linux.tar.gz'
+      - run:
+          name: Creating Build Files
+          command: './premake5 gmake'
+      - run:
+          name: Build and run
+          command: './build.sh'
+


### PR DESCRIPTION
PR adds continuous integration support through Circle CI. Current configuration just builds the project on their debian machine with the GCC compiler, in the future we should update the script to build for multiple platforms with multiple compilers. 