### PR TITLE
Code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,4 +19,4 @@ jobs:
           command: './build.sh'
       - run:
           name: Upload code coverage
-          command: 'bash <(curl -s https://codecov.io/bash)'
+          command: 'bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect reports" '

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,4 +17,6 @@ jobs:
       - run:
           name: Build and run
           command: './build.sh'
-
+      - run:
+          name: Upload code coverage
+          command: 'bash <(curl -s https://codecov.io/bash)'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "third_party/"  # ignore folders and all its contents
+

--- a/gmake/ChocAn-App.make
+++ b/gmake/ChocAn-App.make
@@ -15,14 +15,14 @@ ifeq ($(config),debug)
   TARGETDIR = ../bin/debug
   TARGET = $(TARGETDIR)/ChocAn_debug
   OBJDIR = obj/debug/ChocAn-App
-  DEFINES += -DDEBUG -DMOCKING_ENABLED
+  DEFINES += -DDEBUG
   INCLUDES += -I../include
   FORCE_INCLUDE +=
   ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
-  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -Wall -Wextra -Werror -std=c++11
-  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -Wall -Wextra -Werror -std=c++11
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -std=c++11
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -std=c++11
   ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
-  LIBS += ../lib/debug/libChocAn.a
+  LIBS += ../lib/debug/libChocAn.a -lgcov
   LDDEPS += ../lib/debug/libChocAn.a
   ALL_LDFLAGS += $(LDFLAGS)
   LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)

--- a/gmake/ChocAn.make
+++ b/gmake/ChocAn.make
@@ -15,14 +15,14 @@ ifeq ($(config),debug)
   TARGETDIR = ../lib/debug
   TARGET = $(TARGETDIR)/libChocAn.a
   OBJDIR = obj/debug/ChocAn
-  DEFINES += -DDEBUG -DMOCKING_ENABLED
+  DEFINES += -DDEBUG
   INCLUDES += -I../include
   FORCE_INCLUDE +=
   ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
-  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -Wall -Wextra -Werror -std=c++11
-  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -Wall -Wextra -Werror -std=c++11
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -std=c++11
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -std=c++11
   ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
-  LIBS +=
+  LIBS += -lgcov
   LDDEPS +=
   ALL_LDFLAGS += $(LDFLAGS)
   LINKCMD = $(AR) -rcs "$@" $(OBJECTS)

--- a/gmake/Tests.make
+++ b/gmake/Tests.make
@@ -15,14 +15,14 @@ ifeq ($(config),debug)
   TARGETDIR = ../bin/tests
   TARGET = $(TARGETDIR)/debug_tests
   OBJDIR = obj/debug/Tests
-  DEFINES += -DDEBUG -DMOCKING_ENABLED
+  DEFINES += -DDEBUG
   INCLUDES += -I../third_party -I../include
   FORCE_INCLUDE +=
   ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
-  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -Wall -Wextra -Werror -std=c++11
-  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -Wall -Wextra -Werror -std=c++11
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -std=c++11
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -Werror -g -Wall -Wextra -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -std=c++11
   ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
-  LIBS += ../lib/debug/libChocAn.a
+  LIBS += ../lib/debug/libChocAn.a -lgcov
   LDDEPS += ../lib/debug/libChocAn.a
   ALL_LDFLAGS += $(LDFLAGS)
   LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)

--- a/premake5.lua
+++ b/premake5.lua
@@ -28,7 +28,9 @@ workspace "CS300 Term Project"
     warnings "Extra"
 
     filter "configurations:debug*"   
-        defines { "DEBUG", "MOCKING_ENABLED" } 
+        buildoptions { "-fprofile-arcs", "-ftest-coverage" }
+        defines { "DEBUG" }
+        links "gcov"
         symbols "On"
 
     filter "configurations:release*" 

--- a/tests/datetime_tests.cpp
+++ b/tests/datetime_tests.cpp
@@ -14,6 +14,7 @@ https://github.com/AlexanderJDupree/ChocAn
 */
 
 #include <iostream>
+#include <sstream>
 #include <catch.hpp>
 #include <ChocAn/datetime.hpp>
 
@@ -149,8 +150,8 @@ TEST_CASE("DateTime comparison operators", "[operators], [datetime]")
     }
     SECTION("DateTime objects with differing year values")
     {
-        REQUIRE(DateTime(Day(1), Month(1), Year(2019)) 
-              < DateTime(Day(1), Month(1), Year(2020)));
+        REQUIRE(DateTime(Day(1), Month(1), Year(2020)) 
+              >= DateTime(Day(1), Month(1), Year(2019)));
     }
     SECTION("DateTime objects with differing month values")
     {
@@ -162,5 +163,14 @@ TEST_CASE("DateTime comparison operators", "[operators], [datetime]")
         REQUIRE(DateTime(Day(10), Month(10), Year(2020)) 
               < DateTime(Day(11), Month(10), Year(2020)));
     }
+}
+
+TEST_CASE("Testing ostream operator", "[datetime]")
+{
+    std::stringstream oss;
+
+    oss << DateTime(Day(10), Month(10), Year(2020));
+
+    REQUIRE(oss.str() == "10-10-2020");
 }
 


### PR DESCRIPTION
Debug build will now compile with the -fprofile-arcs and -ftest-coverage flags to generate code coverage and profiling reports. These reports are then compiled and collected by codecov.io for analysis. Having code coverage is great for understanding what pieces of our code is untested or even unnecessary. 