### PR TITLE
Exceptions refactor

### DIFF
--- a/include/ChocAn/app/application_state.hpp
+++ b/include/ChocAn/app/application_state.hpp
@@ -57,7 +57,10 @@ public:
 class Find_Account 
 {
 public:
+    // Represents the next state find account will proceed to
+    enum class Next { View_Account, Delete_Account, Update_Account };
     std::string status;
+    Next next = Next::View_Account;
 };
 
 class View_Account

--- a/include/ChocAn/core/utils/error_type.hpp
+++ b/include/ChocAn/core/utils/error_type.hpp
@@ -1,0 +1,57 @@
+/* 
+ 
+File: error_type.hpp
+
+Brief: error_type is a variant where each member of the union encodes the 
+       offending value and how to correct it
+
+Authors: Daniel Mendez 
+         Alexander Salazar
+         Arman Alauizadeh 
+         Alexander DuPree
+         Kyle Zalewski
+         Dominique Moore
+
+https://github.com/AlexanderJDupree/ChocAn
+ 
+*/
+
+#ifndef CHOCAN_ERROR_TYPE_HPP
+#define CHOCAN_ERROR_TYPE_HPP
+
+#include <string>
+#include <variant>
+
+struct Invalid_Length
+{
+    std::string value;
+    unsigned min;
+    unsigned max;
+};
+
+struct Invalid_Range
+{
+    long int value;
+    long int min;
+    long int max;
+};
+
+struct Incompatible_Values
+{
+    std::string val1;
+    std::string val2;
+};
+
+struct Invalid_Value
+{
+    std::string value;
+    std::string expected;
+};
+
+using Error_Type = std::variant< Invalid_Length
+                               , Invalid_Range
+                               , Invalid_Value
+                               , Incompatible_Values
+                               >;
+
+#endif // CHOCAN_ERROR_TYPE_HPP

--- a/include/ChocAn/core/utils/exception.hpp
+++ b/include/ChocAn/core/utils/exception.hpp
@@ -20,14 +20,15 @@ https://github.com/AlexanderJDupree/ChocAn
 #define CHOCAN_EXCEPTION_HPP
 
 #include <map>
-#include <vector>
 #include <string>
 #include <exception>
+#include <ChocAn/core/utils/error_type.hpp>
 
 class chocan_user_exception : public std::exception
 {
 public:
-    using Info = std::vector<std::string>;
+    // Key is the field name, Error Type holds specific error info
+    using Info = std::map<std::string, Error_Type>;
 
     const Info error_info;
     const std::string error_msg;

--- a/include/ChocAn/core/utils/parsers.hpp
+++ b/include/ChocAn/core/utils/parsers.hpp
@@ -77,11 +77,11 @@ DateTime parse_date(std::string input, const std::string& structure, const std::
     }
     catch(const std::invalid_argument&)
     {
-        throw invalid_datetime("Invalid Datetime, unrecognized values", {});
+        throw invalid_datetime("Invalid Datetime", { { structure, Invalid_Value{ input, "unrecognized format" } }});
     }
     catch(const std::out_of_range&)
     {
-        throw invalid_datetime("Invalid Datetime, unrecognized format", {});
+        throw invalid_datetime("Invalid Datetime", { { structure, Invalid_Value{ input, "unrecognized format" } }});
     }
 }
 

--- a/src/app/state_controller.cpp
+++ b/src/app/state_controller.cpp
@@ -230,9 +230,15 @@ Application_State State_Controller::operator()(Find_Account& state)
 
     if( auto maybe_account = get_account(input))
     {
-        return View_Account { maybe_account.value() };
+        switch (state.next)
+        {
+        case Find_Account::Next::Delete_Account : void();
+        case Find_Account::Next::Update_Account : void();
+        default: return View_Account { maybe_account.value() };
+        }
     }
-    return Find_Account { "Invalid ID" };
+    state.status = "Invalid ID: " + input;
+    return state;
 }
 
 Application_State State_Controller::operator()(Generate_Report& state)

--- a/src/core/address.cpp
+++ b/src/core/address.cpp
@@ -40,21 +40,26 @@ Address::Address( const std::string& street
     // Capitalize state
     for(char& c : _state) { c = std::toupper(c); }
 
-    ( !Validators::length(street, 1, 25) ) 
-        ? errors.push_back("Street address must be less than 25 characters")
-        : void();
-    ( !Validators::length(city, 1, 14) ) 
-        ? errors.push_back("City must be less than 14 character")
-        : void();
-    ( !Validators::length(state, 2, 2) ) 
-        ? errors.push_back("State must be in abbreviated 2 character format")
-        : void();
-    ( US_states.find(_state) == US_states.end() )
-        ? errors.push_back(state + " is not a U.S. state")
-        : void();
-    ( !Validators::length(std::to_string(zip), 5, 5) ) 
-        ? errors.push_back("Zip code must be 5 digits")
-        : void();
+    if( !Validators::length(street, 1, 25) )
+    {
+        errors["Street Address"] = Invalid_Length { street, 1, 25 };
+    }
+    if( !Validators::length(city, 1, 14) )
+    {
+        errors["City"] = Invalid_Length { city, 1, 14 };
+    }
+    if( !Validators::length(state, 2, 2) )
+    {
+        errors["State Length"] =  Invalid_Value { state, "must be in abbreviated 2 character format" };
+    }
+    if( US_states.find(_state) == US_states.end() )
+    {
+        errors["State"] = Invalid_Value { state, "is not a U.S. State (2 character format)"};
+    }
+    if( !Validators::length(std::to_string(zip), 5, 5) ) 
+    {
+        errors["Zip"] = Invalid_Value { std::to_string(zip), "must be 5 digits" };
+    }
     ( !errors.empty() ) 
         ? throw invalid_address("Invalid address values", errors)
         : void();

--- a/src/core/datetime.cpp
+++ b/src/core/datetime.cpp
@@ -26,27 +26,35 @@ DateTime::DateTime(Day day, Month month, Year year, Hours hour, Minutes min, Sec
 {
     chocan_user_exception::Info errors;
 
-    (Validators::range(day.count(), 1, 31))
-        ? void() : errors.push_back("Day should be between 1 - 31");
-
-    (Validators::range(hour.count(), 0, 23))
-        ? void() : errors.push_back("Hour should be between 0-23");
-
-    (Validators::range(min.count(), 0, 60))
-        ? void() : errors.push_back("Minutes should be between 0-60");
-
-    (Validators::range(sec.count(), 0, 60))
-        ? void() : errors.push_back("Seconds should be between 0-60");
-
-    (Validators::range(year.count(), 1970, Year::max().count()))
-        ? void() : errors.push_back("Year should be greater than 1970");
-
-    (Validators::range(month.count(), 1, 12) && ok()) 
-        ? void() : errors.push_back( "Month: " 
-                                   + std::to_string(month.count()) 
-                                   + ", and Day: "
-                                   + std::to_string(day.count())
-                                   + " does not exist." );
+    if( !Validators::range(day.count(), 1, 31) )
+    {
+        errors["Day"] = Invalid_Range { day.count(), 1, 31 };
+    }
+    if( !Validators::range(hour.count(), 0, 23) )
+    {
+        errors["Hour"] = Invalid_Range { hour.count(), 0, 23 };
+    }
+    if( !Validators::range(min.count(), 0, 59) )
+    {
+        errors["Minutes"] = Invalid_Range { min.count(), 0, 59 };
+    }
+    if( !Validators::range(sec.count(), 0, 60) )
+    {
+        errors["Seconds"] = Invalid_Range{ sec.count(), 0, 59 };
+    }
+    if( !Validators::range(year.count(), 1970, Year::max().count()) )
+    {
+        errors["Year"] = Invalid_Value { "", "Must be greater than greater than 1970" };
+    }
+    if( !Validators::range(month.count(), 1, 12) )
+    {
+        errors["Month"] = Invalid_Range { month.count(), 1, 12 };
+    }
+    if(!ok())
+    {
+        errors["Date"] = Incompatible_Values{ "Month=" + std::to_string(month.count())
+                                            , "Day=" + std::to_string(day.count()) };
+    }
     (errors.empty())
         ? void() :throw invalid_datetime("Invalid datetime values", errors);
 }

--- a/src/core/name.cpp
+++ b/src/core/name.cpp
@@ -23,16 +23,18 @@ Name::Name(const std::string& first, const std::string& last)
 {
     chocan_user_exception::Info errors;
 
-    ( !Validators::length(first, 1, 25) ) 
-        ? errors.push_back("First name cannot be empty")
-        : void();
-    ( !Validators::length(last, 1, 25) ) 
-        ? errors.push_back("Last name cannot be empty")
-        : void();
-    ( !Validators::length(first + last, 1, 25) ) 
-        ? errors.push_back("Full name must be less than 25 characters")
-        : void();
-
+    if(!Validators::length(first, 1, 25)) 
+    { 
+        errors["First Name"] = Invalid_Length { first, 1, 25 }; 
+    }
+    if(!Validators::length(last, 1, 25)) 
+    { 
+        errors["Last Name"] = Invalid_Length { first, 1, 25 }; 
+    }
+    if(!Validators::length(first + last, 1, 25))
+    {
+        errors["Full Name"] = Invalid_Length { first + last, 1, 25 };
+    }
     ( !errors.empty() ) 
         ? throw invalid_name("Invalid name length", errors)
         : void();

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -32,18 +32,22 @@ Transaction::Transaction( const Account&     provider
 {
     chocan_user_exception::Info errors;
 
-    ( !std::holds_alternative<Provider>(_provider.type()) )
-        ? errors.push_back("Account is not of type: Provider")
-        : void();
-    ( !std::holds_alternative<Member>(_member.type()) )
-        ? errors.push_back("Account is not of type: Member")
-        : void();
-    ( service_date > _filed_date )
-        ? errors.push_back("Service date cannot be future dated")
-        : void();
-    ( !Validators::length(comments, 0, 100) )
-        ? errors.push_back("Comments field must be less than 100 characters")
-        : void();
+    if( !std::holds_alternative<Provider>(_provider.type()) )
+    {
+        errors["Provider"] = Invalid_Value { "Account", "is not a provider account"};
+    }
+    if( !std::holds_alternative<Member>(_member.type()) )
+    {
+        errors["Member"] = Invalid_Value { "Account", "is not a member account"};
+    }
+    if( service_date > _filed_date )
+    {
+        errors["Service date"] = Invalid_Value { "", "cannot be future dated" };
+    }
+    if( !Validators::length(comments, 0, 100) )
+    {
+        errors["Comments"] = Invalid_Length { comments, 0, 100 };
+    }
     ( !errors.empty() )
         ? throw invalid_transaction("Invalid Transaction fields", errors)
         : void();

--- a/src/core/transaction_builder.cpp
+++ b/src/core/transaction_builder.cpp
@@ -103,7 +103,7 @@ void Transaction_Builder::set_member_acct_field(const std::string& input)
     }
     catch(const std::bad_optional_access&)
     {
-        error.emplace(chocan_user_exception("No member account associated with ID: " + input, {}));
+        error.emplace(chocan_user_exception("Invalid ID" , { {"Member Account", Invalid_Value { input, "does not belong to a member account" }}}));
         return;
     }
     if (std::get<Member>(member_acct.value().type()).status() == Account_Status::Suspended)
@@ -139,7 +139,7 @@ void Transaction_Builder::set_service_date_field(const std::string& input)
 
         if(date > DateTime::get_current_datetime())
         {
-            error.emplace(invalid_datetime("Service Date cannot be future dated", {}));
+            error.emplace(invalid_datetime("Invalid Datetime", {{"Service Date", Invalid_Value{"", "cannot be future dated"}}}));
             return;
         }
     
@@ -160,7 +160,7 @@ void Transaction_Builder::set_service_field(const std::string& input)
     }
     catch(const std::bad_optional_access&)
     {
-        error.emplace(chocan_user_exception("No service associated with service code: " + input, {}));
+        error.emplace(chocan_user_exception("Invalid Service", {{"Code", Invalid_Value{input, "is not associated with a service"}}}));
     }
 }
 

--- a/views/Find Account.txt
+++ b/views/Find Account.txt
@@ -5,4 +5,4 @@
 ( Entering 'cancel' will cancel the return to the previous menu )
 
 <@status>
-Enter ID number of account you wish to view: <prompt>
+<@string_prompt> <prompt>


### PR DESCRIPTION
This PR greatly expands the functionality of the chocan_user_exception. Previously, the info function returned a vector of strings that the contained messages about the nature of the errors. Now, we use a mapping between strings and a Error_Type union. The string key is the field name that caused the error, and the Error_Type encodes the exact nature of what went wrong. 

This PR also updates the Find Account state to be more dynamic. Now we can specify what state we will be transitioning to when we create the Find_Account state. Which will be useful for issues #26  and #27 