### PR TITLE
Refactored clear screen into a viewer command

### DIFF
--- a/src/view/terminal_state_viewer.cpp
+++ b/src/view/terminal_state_viewer.cpp
@@ -29,7 +29,8 @@ Terminal_State_Viewer::Terminal_State_Viewer( bool compact_output
     , command_table  ( {
           { "header",       [&](){ return render_view("header");  } }
         , { "footer",       [&](){ return render_view("footer");  } }
-        , { "prompt",       [&](){ event_callback(); } }
+        , { "clear_screen", [&](){ return clear_screen();         } }
+        , { "prompt",       [&](){ return event_callback();       } }
     } )
     , resources ({})
     , compact_output( compact_output )
@@ -47,7 +48,6 @@ void Terminal_State_Viewer::render_state(const Application_State& state, Callbac
 void Terminal_State_Viewer::update()
 {
     resources.update();
-    if(!compact_output) { clear_screen(); }
     try
     {
         render_view(resources.table.at("state_name"));
@@ -133,5 +133,10 @@ void Terminal_State_Viewer::execute_command(const std::string& command)
 
 void Terminal_State_Viewer::clear_screen() const
 {
-    out_stream << std::string(100, '\n');
+    if(!compact_output)
+    {
+        out_stream << std::string(100, '\n');
+    }
+
+    return;
 }

--- a/views/Manager Menu.txt
+++ b/views/Manager Menu.txt
@@ -1,3 +1,4 @@
+<clear_screen>
 <header>
 
 0) Return to Login Screen

--- a/views/Provider Menu.txt
+++ b/views/Provider Menu.txt
@@ -1,3 +1,4 @@
+<clear_screen>
 <header> 
 
 0) Return to Login Screen


### PR DESCRIPTION
Clearing the screen is no longer the default behavior. If you want to clear your screen before, or even during the rendering of your view just add the <clear_screen> in the view file. Currently the only views that clear the screen are the provider and manager menus. Also, --compact-output flag will ignore the <clear_screen> command and just print everything continuously. 